### PR TITLE
Correction to height calculation of list

### DIFF
--- a/src/DraggableList.js
+++ b/src/DraggableList.js
@@ -67,7 +67,7 @@ class DraggableGridView extends Component {
 
   get wrapperStyle() {
     const { itemsPerRow, itemHeight } = this.props;
-    const height = (Math.round(this.itemsLength / itemsPerRow) + 1) * itemHeight;
+    const height = (Math.floor(this.itemsLength / itemsPerRow) + 1) * itemHeight;
 
     return { height };
   }


### PR DESCRIPTION
The height of the list was calculated using Math.round, which resulted in the row being twice the itemHeight after two items in the list. Interchanging this to Math.floor provides the correct height calculation.